### PR TITLE
Create Mesos client.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,12 @@ bytes = "0.4"
 failure = "0.1"
 futures = "0.1"
 hyper = "0.11"
+lazy_static = "1.0"
+log = "0.4"
 mime = "0.3"
 protobuf = { version = "1.4", features = ["with-bytes"] }
 spectral = "0.6"
 tokio-core = "0.1"
+
+[dev-dependencies]
+simple_logger = "0.5"

--- a/src/client.rs
+++ b/src/client.rs
@@ -185,6 +185,12 @@ impl Stream for Events {
     }
 }
 
+pub struct Client {
+    pub framework_id: str,
+    stream_id: str,
+    pub events: Events,
+}
+
 #[cfg(test)]
 mod tests {
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -16,7 +16,7 @@ use protobuf::core::{parse_from_bytes, Message};
 use scheduler;
 use tokio_core::reactor::Handle;
 
-use std::str;
+use std::{fmt, str};
 
 #[derive(Fail, Debug)]
 pub enum DecoderError {
@@ -192,6 +192,12 @@ pub struct Client {
     pub framework_id: String,
     stream_id: String,
     pub events: Events,
+}
+
+impl fmt::Debug for Client {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "Client {{ framework_id: {}, stream_id: {} }}", self.framework_id, self.stream_id)
+    }
 }
 
 header! { (MesosStreamIdHeader, "Mesos-Stream-Id") => [String] }
@@ -388,6 +394,6 @@ mod tests {
         let events = Events::new(hyper::Body::empty());
         let result = Client::client_from(None, events, String::from("some stream id"));
 
-        assert_that(&result).is_ok();
+        assert_that(&result).is_err();
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,9 +5,13 @@ extern crate failure;
 extern crate futures;
 #[macro_use]
 extern crate hyper;
+#[macro_use]
+extern crate lazy_static;
+#[macro_use]
+extern crate log;
 extern crate mime;
 extern crate protobuf;
-extern crate spectral;
+extern crate spectral; // TODO: Move to test dependencies.
 extern crate tokio_core;
 
 pub mod client;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,10 @@
 extern crate bytes;
-#[macro_use] extern crate failure;
-#[macro_use] extern crate futures;
-#[macro_use] extern crate hyper;
+#[macro_use]
+extern crate failure;
+#[macro_use]
+extern crate futures;
+#[macro_use]
+extern crate hyper;
 extern crate mime;
 extern crate protobuf;
 extern crate spectral;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,9 +1,8 @@
 extern crate bytes;
-#[macro_use]
-extern crate failure;
-#[macro_use]
-extern crate futures;
-extern crate hyper;
+#[macro_use] extern crate failure;
+#[macro_use] extern crate futures;
+#[macro_use] extern crate hyper;
+extern crate mime;
 extern crate protobuf;
 extern crate spectral;
 extern crate tokio_core;

--- a/tests/mesos.rs
+++ b/tests/mesos.rs
@@ -38,7 +38,7 @@ mod integration {
         let uri = "http://localhost:5050/api/v1/scheduler"
             .parse::<Uri>()
             .unwrap();
-        let client = Client.connect(uri, &handle);
+        let client = Client.connect(&handle, uri, framework_info);
 
         let events: Events = core.run(client).unwrap().events;
         let w = events.map(|event| event.get_field_type()).take(2).collect();

--- a/tests/mesos.rs
+++ b/tests/mesos.rs
@@ -9,12 +9,11 @@ extern crate tokio_core;
 #[cfg(test)]
 mod integration {
 
-    use futures::{Future, Stream};
-    use hyper::{Client, Method, Request, Uri};
-    use hyper::header::{qitem, Accept, ContentType};
+    use futures::Stream;
+    use hyper::Uri;
     use mime;
     use async_mesos::client;
-    use async_mesos::client::{Decoder, Events};
+    use async_mesos::client::{Client, Events};
     use async_mesos::mesos;
     use async_mesos::scheduler;
     use protobuf::core::{parse_from_bytes, Message};
@@ -38,14 +37,13 @@ mod integration {
         let uri = "http://localhost:5050/api/v1/scheduler"
             .parse::<Uri>()
             .unwrap();
-        let client = Client.connect(&handle, uri, framework_info);
+        let client = Client::connect(&handle, uri, framework_info);
 
         let events: Events = core.run(client).unwrap().events;
-        let w = events.map(|event| event.get_field_type()).take(2).collect();
+        let w = events.map(|event| event.get_field_type()).take(1).collect();
 
         let result = core.run(w).unwrap();
         assert_that(&result).is_equal_to(vec![
-            scheduler::Event_Type::SUBSCRIBED,
             scheduler::Event_Type::HEARTBEAT,
         ]);
     }

--- a/tests/mesos.rs
+++ b/tests/mesos.rs
@@ -3,6 +3,7 @@ extern crate futures;
 extern crate hyper;
 extern crate mime;
 extern crate protobuf;
+extern crate simple_logger;
 extern crate spectral;
 extern crate tokio_core;
 
@@ -11,16 +12,17 @@ mod integration {
 
     use futures::Stream;
     use hyper::Uri;
-    use mime;
-    use async_mesos::client;
     use async_mesos::client::{Client, Events};
     use async_mesos::mesos;
     use async_mesos::scheduler;
+    use simple_logger;
     use spectral::prelude::*;
     use tokio_core::reactor::Core;
 
     #[test]
     fn connect() {
+        simple_logger::init().unwrap();
+
         let mut core = Core::new().unwrap();
         let handle = core.handle();
 

--- a/tests/mesos.rs
+++ b/tests/mesos.rs
@@ -16,9 +16,6 @@ mod integration {
     use async_mesos::client::{Client, Events};
     use async_mesos::mesos;
     use async_mesos::scheduler;
-    use protobuf::core::{parse_from_bytes, Message};
-    use protobuf::repeated::RepeatedField;
-    use protobuf::stream::CodedInputStream;
     use spectral::prelude::*;
     use tokio_core::reactor::Core;
 

--- a/tests/mesos.rs
+++ b/tests/mesos.rs
@@ -40,8 +40,6 @@ mod integration {
         let w = events.map(|event| event.get_field_type()).take(1).collect();
 
         let result = core.run(w).unwrap();
-        assert_that(&result).is_equal_to(vec![
-            scheduler::Event_Type::HEARTBEAT,
-        ]);
+        assert_that(&result).is_equal_to(vec![scheduler::Event_Type::HEARTBEAT]);
     }
 }


### PR DESCRIPTION
The connect method handles the request to Mesos' event stream.
It extracts the framework ID from the first event and captures the
stream id. These are required for future request to the API.