### PR TITLE
Fold over events and update state.

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -298,6 +298,28 @@ impl Client {
         call
     }
 
+    /// Construct Acknowledge Call
+    ///
+    /// # Arguments
+    ///
+    ///  * `framework_id` - Id of this registered client.
+    /// * `update_status` - The task status sent along with the update event.
+    pub fn acknowledge(framework_id: String, mut update_status: mesos::TaskStatus) -> scheduler::Call {
+        let mut call = scheduler::Call::new();
+        let mut ack = scheduler::Call_Acknowledge::new();
+
+        ack.set_agent_id(update_status.take_agent_id());
+        ack.set_task_id(update_status.take_task_id());
+        ack.set_uuid(update_status.take_uuid());
+
+        let mut id = mesos::FrameworkID::new();
+        id.set_value(framework_id);
+        call.set_framework_id(id);
+        call.set_acknowledge(ack);
+        call.set_field_type(scheduler::Call_Type::ACKNOWLEDGE);
+        call
+    }
+
     /// Construct offer launch operation.
     ///
     /// # Argument

--- a/src/client.rs
+++ b/src/client.rs
@@ -424,65 +424,6 @@ impl Client {
             Err(format_err!("Did not receive Mesos SUBSCRIBED event."))
         }
     }
-
-    pub fn update<F, U>(self, f: F) -> ElmUpdate<F, U>
-        where U: IntoFuture<Item = (), Error = failure::Error>,
-              F: FnMut(scheduler::Event, &mut State) -> U
-    {
-        let state = State { framework_id: self.framework_id.clone(), stream_id: self.stream_id.clone() };
-        ElmUpdate::new(state, self.events, f)
-    }
-}
-
-#[derive(Clone, Debug)]
-pub struct State {
-    pub framework_id: String,
-    pub stream_id: String,
-}
-
-pub struct ElmUpdate<F, U>
-    where U: IntoFuture<Item = (), Error = failure::Error>,
-          F: FnMut(scheduler::Event, &mut State) -> U
-{
-    state: State, // TODO: Make State generic.
-    events: Events,
-    f: F,
-    fut: Option<U::Future>,
-}
-
-impl<F, U> ElmUpdate<F, U>
-    where U: IntoFuture<Item = (), Error = failure::Error>,
-          F: FnMut(scheduler::Event, &mut State) -> U
-{
-
-    fn new(state: State, events: Events, f: F) -> ElmUpdate<F, U>
-    {
-        ElmUpdate { state, events, f, fut: None }
-    }
-}
-
-impl<F, U> Future for ElmUpdate<F, U>
-    where U: IntoFuture<Item = (), Error = failure::Error>,
-          F: FnMut(scheduler::Event, &mut State) -> U
-{
-    type Item = ();
-    type Error = failure::Error;
-
-    fn poll(&mut self) -> Poll<(), Self::Error> {
-        loop {
-            if let Some(mut fut) = self.fut.take() {
-                if fut.poll()?.is_not_ready() {
-                    self.fut = Some(fut);
-                    return Ok(Async::NotReady);
-                }
-            }
-
-            match try_ready!(self.events.poll()) {
-                Some(event) => self.fut = Some((self.f)(event, &mut self.state).into_future()),
-                None => return Ok(Async::Ready(())),
-            }
-        }
-    }
 }
 
 #[cfg(test)]

--- a/src/client.rs
+++ b/src/client.rs
@@ -321,37 +321,29 @@ impl Client {
     /// * `task_id` - The id of the launched task.
     /// * `agent_id` - The agent where the task is lauched.
     /// * `resources` - The resources to use.
-    /// * `executor` - The execution of the task.
+    /// * `commdn` - The command of the task to execute.
     pub fn task_info(
         name: String,
         task_id: mesos::TaskID,
         agent_id: mesos::AgentID,
         resources: Vec<mesos::Resource>,
-        executor: mesos::ExecutorInfo,
+        command: mesos::CommandInfo,
     ) -> mesos::TaskInfo {
         let mut task_info = mesos::TaskInfo::new();
         task_info.set_name(name);
         task_info.set_task_id(task_id);
         task_info.set_agent_id(agent_id);
         task_info.set_resources(RepeatedField::from_vec(resources));
-        task_info.set_executor(executor);
+        task_info.set_command(command);
         task_info
     }
 
-    /// Construct an executor for a shell command.
-    pub fn executor_shell(executor_id: String, command: String) -> mesos::ExecutorInfo {
-        let mut executor = mesos::ExecutorInfo::new();
-
-        let mut id = mesos::ExecutorID::new();
-        id.set_value(executor_id);
-
+    /// Construct shell command.
+    pub fn command_shell(command: String) -> mesos::CommandInfo{
         let mut command_info = mesos::CommandInfo::new();
         command_info.set_shell(true);
         command_info.set_value(command);
-
-        executor.set_executor_id(id);
-        executor.set_command(command_info);
-        executor
+        command_info
     }
 
     pub fn resource_cpu(cpus: f64) -> mesos::Resource {
@@ -579,10 +571,9 @@ mod tests {
             .that(&resource_mem.is_initialized())
             .is_true();
 
-        let executor =
-            Client::executor_shell(String::from("my_executor"), String::from("sleep 100000"));
-        asserting(&"Executor is initialized")
-            .that(&executor.is_initialized())
+        let command = Client::command_shell(String::from("sleep 100000"));
+        asserting(&"Command is initialized")
+            .that(&command.is_initialized())
             .is_true();
 
         let task_info = Client::task_info(
@@ -590,7 +581,7 @@ mod tests {
             task_id,
             agent_id,
             vec![resource_cpu, resource_mem],
-            executor,
+            command,
         );
         asserting(&"Task info is initialized")
             .that(&task_info.is_initialized())

--- a/tests/mesos.rs
+++ b/tests/mesos.rs
@@ -179,7 +179,6 @@ mod integration {
                                 status.get_message()
                             );
 
-                            // TODO: Acknowledge task status update.
                             let ack_call = Client::acknowledge(state.framework_id.clone(), status);
                             let ack_uri = "http://localhost:5050/api/v1/scheduler"
                                 .parse::<Uri>()

--- a/tests/mesos.rs
+++ b/tests/mesos.rs
@@ -112,8 +112,13 @@ mod integration {
                         scheduler::Event_Type::OFFERS => {
                             info!("Received offer.");
 
+                            // We already launched a task.
+                            if state.task_id.is_some() {
+                                info!("Ignoring offer because task is already launching.");
+                                return Box::new(future::result(Ok(state)));
+                            }
+
                             // Create task for offer.
-                            // TODO: Launch task only once!
                             let mut offer = event.take_offers().take_offers()[0].clone();
                             let offer_id = offer.take_id();
                             let agent_id = offer.take_agent_id();

--- a/tests/mesos.rs
+++ b/tests/mesos.rs
@@ -59,12 +59,6 @@ mod integration {
         assert_that(&result).is_equal_to(vec![scheduler::Event_Type::HEARTBEAT]);
     }
 
-    #[derive(Clone, Debug)]
-    struct State {
-        pub framework_id: String,
-        pub stream_id: String,
-    }
-
     fn log_response_body(
         chunks: Result<Vec<hyper::Chunk>, hyper::Error>,
     ) -> Result<(), failure::Error> {
@@ -98,18 +92,8 @@ mod integration {
         let future_client = Client::connect(&handle, uri, framework_info);
 
         // Process events and start and stop a simple task.
-        let work = future_client
-            .into_stream()
-            .map(|client| {
-                let state = stream::repeat::<_, failure::Error>(State {
-                    framework_id: client.framework_id.clone(),
-                    stream_id: client.stream_id.clone(),
-                });
-                client.events.zip(state)
-            })
-            .flatten()
-            .for_each(
-                |(mut event, state)| -> Box<Future<Item = _, Error = failure::Error>> {
+        let work = future_client.and_then(|client| {
+                client.update(|mut event, ref mut state| -> Box<Future<Item = _, Error = failure::Error>> {
                     match event.get_field_type() {
                         scheduler::Event_Type::OFFERS => {
                             info!("Received offer.");
@@ -140,13 +124,13 @@ mod integration {
                             );
                             let operation = Client::launch_operation(vec![task_info]);
                             let call =
-                                Client::accept(state.framework_id, vec![offer_id], vec![operation]);
+                                Client::accept(state.framework_id.clone(), vec![offer_id], vec![operation]);
 
                             // Make call
                             let uri = "http://localhost:5050/api/v1/scheduler"
                                 .parse::<Uri>()
                                 .unwrap();
-                            let request = Client::request_for(uri, call, Some(state.stream_id));
+                            let request = Client::request_for(uri, call, Some(state.stream_id.clone()));
                             let http_client = hyper::Client::new(&handle);
                             let s = http_client
                                 .request(request)
@@ -173,13 +157,13 @@ mod integration {
                             );
 
                             // TODO: Stop connection.
-                            let call = Client::teardown(state.framework_id);
+                            let call = Client::teardown(state.framework_id.clone());
 
                             // Make call
                             let uri = "http://localhost:5050/api/v1/scheduler"
                                 .parse::<Uri>()
                                 .unwrap();
-                            let request = Client::request_for(uri, call, Some(state.stream_id));
+                            let request = Client::request_for(uri, call, Some(state.stream_id.clone()));
                             let http_client = hyper::Client::new(&handle);
                             let s = http_client
                                 .request(request)
@@ -198,8 +182,8 @@ mod integration {
                             Box::new(future::result(Ok(())))
                         }
                     }
-                },
-            );
+                })
+            });
 
         core.run(work).unwrap();
     }


### PR DESCRIPTION
This gets us closer to an Elm loop. We fold over all Mesos events
and update a global state. All futures are started in a sequential
order except for "fire and forget" requests such as the acknowledge
of a task status update which mimic `Task` in an Elm loop.